### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          # GH_PAT must be a classic or fine-grained PAT with contents/write access
+          # to this repo plus push access to Sophylax/homebrew-tap and Sophylax/scoop-bucket.
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ brews:
   - repository:
       owner: Sophylax
       name: homebrew-tap
+      branch: main
     homepage: https://github.com/Sophylax/envguard
     description: Zero-config pre-commit secret scanner for Git repositories.
     license: MIT
@@ -50,6 +51,7 @@ scoops:
   - repository:
       owner: Sophylax
       name: scoop-bucket
+      branch: main
     homepage: https://github.com/Sophylax/envguard
     description: Zero-config pre-commit secret scanner for Git repositories.
     license: MIT


### PR DESCRIPTION
## Summary
- add a tag-driven GitHub Actions release workflow for Goreleaser
- pin Homebrew and Scoop publishing branches to main
- configure the workflow to use the GH_PAT secret for release publishing and cross-repo pushes

## Testing
- go test ./...

Closes #4