### PR TITLE
test: expand CLI and scanner coverage

### DIFF
--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sophylax/envguard/scanner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCommandJSONOutputIsParseable(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForTest(t, tempDir)
+
+	target := filepath.Join(tempDir, "secret.js")
+	require.NoError(t, os.WriteFile(target, []byte("const key = \"AKIA1234567890ABCDEF\";\n"), 0o644))
+
+	cmd := newCheckCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	// Keep Cobra from mixing usage/error text into stdout so --json output stays parseable in tests.
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{target, "--json"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, ErrFindings)
+
+	var findings []scanner.Finding
+	require.NoError(t, json.Unmarshal(output.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	assert.Equal(t, "HIGH", findings[0].Severity)
+	assert.Equal(t, "AWS Access Key", findings[0].RuleName)
+}
+
+func TestCheckCommandSeverityFilterAppliesToJSONOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForTest(t, tempDir)
+
+	target := filepath.Join(tempDir, "mixed.txt")
+	require.NoError(t, os.WriteFile(target, []byte("const key = \"AKIA1234567890ABCDEF\";\nconst token = \"kR9mXp2Qa7Vz1Ld8Hs4Ty6Nu0We3\";\n"), 0o644))
+
+	cmd := newCheckCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	// Keep Cobra from mixing usage/error text into stdout so --json output stays parseable in tests.
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{target, "--json", "--severity", "HIGH"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, ErrFindings)
+
+	var findings []scanner.Finding
+	require.NoError(t, json.Unmarshal(output.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	assert.Equal(t, "HIGH", findings[0].Severity)
+	assert.Equal(t, "AWS Access Key", findings[0].RuleName)
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(wd))
+	})
+}

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFindsConfigFromParentDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	nestedDir := filepath.Join(repoRoot, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	configPath := filepath.Join(repoRoot, ".envguard.yml")
+	configBody := []byte("entropy_threshold: 5.1\nmin_length: 12\nallow_test_fixtures: true\n")
+	require.NoError(t, os.WriteFile(configPath, configBody, 0o644))
+
+	cfg, loadedPath, err := Load(nestedDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, configPath, loadedPath)
+	assert.Equal(t, 5.1, cfg.EntropyThreshold)
+	assert.Equal(t, 12, cfg.MinLength)
+	assert.True(t, cfg.AllowTestFixtures)
+}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,4 +41,59 @@ func TestScanDirtyFixture(t *testing.T) {
 	assert.Equal(t, 1, rules["Slack Token"])
 	assert.Equal(t, 1, rules["Generic API Key"])
 	assert.Equal(t, 1, rules["Database URL"])
+}
+
+func TestScanWarnsWhenFileExceedsMaxSize(t *testing.T) {
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "large.txt")
+	require.NoError(t, os.WriteFile(target, bytes.Repeat([]byte("a"), 2048), 0o644))
+
+	cfg := config.Default()
+	cfg.MaxFileSizeKB = 1
+
+	engine, err := NewEngine(cfg, allowlist.Set{})
+	require.NoError(t, err)
+
+	findings, err := engine.ScanPaths([]string{target})
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+	require.Len(t, engine.Warnings(), 1)
+	assert.Contains(t, engine.Warnings()[0], "exceeds limit")
+}
+
+func TestEnvFileDetectionCanBeAllowlisted(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForTest(t, tempDir)
+
+	target := filepath.Join(tempDir, ".env")
+	require.NoError(t, os.WriteFile(target, []byte("HELLO=world\n"), 0o644))
+
+	cfg := config.Default()
+	cfg.ExcludePaths = nil
+
+	engine, err := NewEngine(cfg, allowlist.Set{})
+	require.NoError(t, err)
+
+	findings, err := engine.ScanPaths([]string{target})
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, ".env file staged", findings[0].RuleName)
+
+	allow := allowlist.Set{findings[0].Fingerprint: struct{}{}}
+	engine, err = NewEngine(cfg, allow)
+	require.NoError(t, err)
+
+	findings, err = engine.ScanPaths([]string{target})
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(wd))
+	})
 }


### PR DESCRIPTION
## Summary
- add config loader coverage for parent-directory discovery
- add command tests for parseable --json output and severity filtering
- add scanner coverage for oversized-file warnings and allowlisted .env detection
- document why Cobra output is silenced in JSON command tests

## Testing
- go test ./config ./cmd ./scanner
- go test ./...

Closes #7