### PR TITLE
fix: skip deleted staged files during scans

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -45,7 +45,7 @@ func newCheckCommand() *cobra.Command {
 				return fmt.Errorf("load allowlist: %w", err)
 			}
 
-			paths, scope, err := resolveScanPaths(args, scanAll)
+			paths, scope, pathWarnings, err := resolveScanPaths(args, scanAll)
 			if err != nil {
 				return fmt.Errorf("resolve scan paths: %w", err)
 			}
@@ -70,7 +70,8 @@ func newCheckCommand() *cobra.Command {
 				if err := reporter.PrintScanHeader(cmd.OutOrStdout(), len(paths), scope); err != nil {
 					return fmt.Errorf("print header: %w", err)
 				}
-				if err := reporter.PrintWarnings(cmd.OutOrStdout(), engine.Warnings()); err != nil {
+				warnings := append(pathWarnings, engine.Warnings()...)
+				if err := reporter.PrintWarnings(cmd.OutOrStdout(), warnings); err != nil {
 					return fmt.Errorf("print warnings: %w", err)
 				}
 				if len(findings) == 0 {
@@ -100,25 +101,34 @@ func newCheckCommand() *cobra.Command {
 	return cmd
 }
 
-func resolveScanPaths(args []string, scanAll bool) ([]string, string, error) {
+func resolveScanPaths(args []string, scanAll bool) ([]string, string, []string, error) {
 	if len(args) == 1 {
-		return []string{args[0]}, "path entries", nil
+		return []string{args[0]}, "path entries", nil, nil
 	}
 	if scanAll {
-		return []string{"."}, "working tree files", nil
+		return []string{"."}, "working tree files", nil, nil
 	}
 	staged, err := envgitStagedFiles()
 	if err != nil {
-		return nil, "", fmt.Errorf("list staged files: %w", err)
+		return nil, "", nil, fmt.Errorf("list staged files: %w", err)
 	}
 	if len(staged) == 0 {
-		return []string{}, "staged files", nil
+		return []string{}, "staged files", nil, nil
 	}
 	paths := make([]string, 0, len(staged))
+	warnings := make([]string, 0)
 	for _, path := range staged {
-		paths = append(paths, filepath.Clean(path))
+		cleanPath := filepath.Clean(path)
+		if _, err := os.Stat(cleanPath); err != nil {
+			if os.IsNotExist(err) {
+				warnings = append(warnings, fmt.Sprintf("skipping %s: path no longer exists", cleanPath))
+				continue
+			}
+			return nil, "", nil, fmt.Errorf("stat staged path %s: %w", cleanPath, err)
+		}
+		paths = append(paths, cleanPath)
 	}
-	return paths, "staged files", nil
+	return paths, "staged files", warnings, nil
 }
 
 func filterBySeverity(findings []scanner.Finding, severity string) []scanner.Finding {

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -86,15 +86,32 @@ func TestCheckCommandSkipsMissingStagedFiles(t *testing.T) {
 	output := &bytes.Buffer{}
 	cmd.SetOut(output)
 	cmd.SetErr(io.Discard)
-	cmd.SetArgs([]string{"--json"})
+	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	require.ErrorIs(t, err, ErrFindings)
+	assert.Contains(t, output.String(), "[envguard] scanning 1 staged files...")
+	assert.Contains(t, output.String(), "[envguard] warning: skipping deleted.txt: path no longer exists")
+	assert.Contains(t, output.String(), "AWS Access Key")
+}
 
-	var findings []scanner.Finding
-	require.NoError(t, json.Unmarshal(output.Bytes(), &findings))
-	require.Len(t, findings, 1)
-	assert.Equal(t, "AWS Access Key", findings[0].RuleName)
+func TestCheckCommandExplicitMissingPathStillErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	chdirForTest(t, tempDir)
+
+	missing := filepath.Join(tempDir, "missing.txt")
+
+	cmd := newCheckCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{missing})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scan paths")
+	assert.Contains(t, err.Error(), "stat path")
 }
 
 func chdirForTest(t *testing.T, dir string) {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -96,10 +96,6 @@ func (e *Engine) expandPaths(paths []string) ([]string, error) {
 		}
 		info, err := os.Stat(abs)
 		if err != nil {
-			if os.IsNotExist(err) {
-				e.warnings = append(e.warnings, fmt.Sprintf("skipping %s: path no longer exists", input))
-				continue
-			}
 			return nil, fmt.Errorf("stat path %s: %w", abs, err)
 		}
 		if info.IsDir() {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -61,22 +61,6 @@ func TestScanWarnsWhenFileExceedsMaxSize(t *testing.T) {
 	assert.Contains(t, engine.Warnings()[0], "exceeds limit")
 }
 
-func TestScanSkipsMissingPathWithWarning(t *testing.T) {
-	tempDir := t.TempDir()
-	target := filepath.Join(tempDir, "deleted.txt")
-
-	cfg := config.Default()
-	engine, err := NewEngine(cfg, allowlist.Set{})
-	require.NoError(t, err)
-
-	findings, err := engine.ScanPaths([]string{target})
-	require.NoError(t, err)
-	assert.Empty(t, findings)
-	require.Len(t, engine.Warnings(), 1)
-	assert.Contains(t, engine.Warnings()[0], "path no longer exists")
-	assert.Contains(t, engine.Warnings()[0], "deleted.txt")
-}
-
 func TestEnvFileDetectionCanBeAllowlisted(t *testing.T) {
 	tempDir := t.TempDir()
 	chdirForTest(t, tempDir)


### PR DESCRIPTION
## Summary
- skip missing scan paths with a warning instead of failing the scan
- cover the staged-deletion case in scanner, git, and command tests
- keep normal findings behavior unchanged for existing files

Closes #20